### PR TITLE
Add AUR link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Interface heavily inspired by [Thunar's 'bulk renamer'](https://docs.xfce.org/xf
   - Double-click the .deb installation file and install via your package manager. The executable will be located at /usr/local/bin/Batch_Renamer.
 
 - On Arch based Linux distributions:
-  - Double-click the .tar installation file and install via your package manager. 
+  - Double-click the .tar installation file and install via your package manager  
+    or use the [AUR package](https://aur.archlinux.org/packages/bionic-batch-renamer-git)
 
 #### Authors:
 


### PR DESCRIPTION
I have created a PKGBUILD for this tool, which builds from source, for anyone who does not want to download the binary.
It also correctly configures the service menu entries for Plasma 6, i.e. also copy the desktop file to /usr/share/kio/servicemenus.

If you want to include a link to the AUR page, feel free to merge this PR or adjust to your liking.