### PR TITLE
Update the AUR link to point to the stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Interface heavily inspired by [Thunar's 'bulk renamer'](https://docs.xfce.org/xf
   - Double-click the .deb installation file and install via your package manager. The executable will be located at /usr/local/bin/Batch_Renamer.
 
 - On Arch based Linux distributions:
-  - Via [AUR package](https://aur.archlinux.org/packages/bionic-batch-renamer-git)
+  - Via [AUR package (Stable Version)](https://aur.archlinux.org/packages/bionic-batch-renamer) or [AUR package (Development Version)](https://aur.archlinux.org/packages/bionic-batch-renamer-git)
   - **_or_** Double-click the .tar installation file and install via your package manager
 
 #### Authors:


### PR DESCRIPTION
To avoid confusion, I've replaced the single AUR package with a stable version (tracks releases) and the development version.
This PR updates the README to point to those packages.

Fixes #18 